### PR TITLE
Introduce LRU behavior guarantees

### DIFF
--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -63,9 +63,9 @@ class ExpiringDict(OrderedDict):
     def __setitem__(self, key, value):
         """ Set d[key] to value. """
         with self.lock:
-            if len(self) == self.max_len:
-                self.popitem(last=False)
             OrderedDict.__setitem__(self, key, (value, time()))
+            if len(self) > self.max_len:
+                self.popitem(last=False)
 
     def pop(self, key, default=None):
         """ Get item from the dict and remove it.
@@ -146,3 +146,6 @@ class ExpiringDict(OrderedDict):
     def viewvalues(self):
         """ Return a new view of the dictionary's values. """
         raise NotImplementedError()
+
+    def to_dict(self):
+        return dict(self.items())

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -1,2 +1,0 @@
-from mock import Mock, patch
-from nose.tools import *

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -140,3 +140,41 @@ def test_update_at_the_top_capacity():
     d['b'] = 4
     # Then: key `a` is still in the dictionary.
     eq_({'a': 1, 'b': 4, 'c': 3}, d.to_dict())
+
+
+def test_lru_behavior_on_write():
+    """
+    If a new element is added to the dictionary that has reached the maximum of
+    its capacity then the least recently used element is thrown away to give
+    space to the new element.
+
+    In particular it checks that value update is qualified as usage.
+    """
+    # Given
+    d = ExpiringDict(max_len=2, max_age_seconds=10)
+    d['a'] = 1
+    d['b'] = 2
+    # When
+    d['a'] = 3
+    d['c'] = 4
+    # Then: Least recently used key `b` has been cast away.
+    eq_({'a': 3, 'c': 4}, d.to_dict())
+
+
+def test_lru_behavior_on_read():
+    """
+    If a new element is added to the dictionary that has reached the maximum of
+    its capacity then the least recently used element is thrown away to give
+    space to the new element.
+
+    In particular it checks that value reading is qualified as usage.
+    """
+    # Given
+    d = ExpiringDict(max_len=2, max_age_seconds=10)
+    d['a'] = 1
+    d['b'] = 2
+    # When
+    print(d['a'])
+    d['c'] = 4
+    # Then: Least recently used key `b` has been cast away.
+    eq_({'a': 1, 'c': 4}, d.to_dict())

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -1,5 +1,7 @@
-from . import *
-from expiringdict import *
+from collections import OrderedDict
+from mock import Mock, patch
+from nose.tools import ok_, eq_, assert_raises
+from expiringdict import ExpiringDict
 from time import sleep
 
 
@@ -121,3 +123,20 @@ def test_not_implemented():
     assert_raises(NotImplementedError, d.viewitems)
     assert_raises(NotImplementedError, d.viewkeys)
     assert_raises(NotImplementedError, d.viewvalues)
+
+
+def test_update_at_the_top_capacity():
+    """
+    Reveals a bug where an update of an existing key when a dictionary has
+    maxed out its capacity resulting in a loss of the least recently added
+    element.
+    """
+    # Given
+    d = ExpiringDict(max_len=3, max_age_seconds=10)
+    d['a'] = 1
+    d['b'] = 2
+    d['c'] = 3
+    # When
+    d['b'] = 4
+    # Then: key `a` is still in the dictionary.
+    eq_({'a': 1, 'b': 4, 'c': 3}, d.to_dict())


### PR DESCRIPTION
In the event of maxed out capacity new records will push away the least recently used elements. An element is considered to be used if it is updated, or if is read while being unexpired.