### PR TITLE
Fix issue #2: Add support for Py 2.6.

### DIFF
--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,0 +1,2 @@
+recursive-include *.py
+include README.md LICENSE

--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -16,8 +16,13 @@ NOTE: iteration over dict and also keys() do not remove expired values!
 '''
 
 from time import time
-from collections import OrderedDict
 from threading import RLock
+
+try:
+    from collections import OrderedDict
+except ImportError:
+    # Python < 2.7
+    from ordereddict import OrderedDict
 
 
 class ExpiringDict(OrderedDict):

--- a/tox.ini
+++ b/tox.ini
@@ -1,0 +1,18 @@
+# Tox (http://tox.testrun.org/) is a tool for running tests
+# in multiple virtualenvs. This configuration file will run the
+# test suite on all supported python versions. To use it, "pip install tox"
+# and then run "tox" from this directory.
+
+[tox]
+envlist = py26, py27
+
+[testenv]
+commands = nosetests
+deps =
+    nose
+    mock
+
+[testenv:py26]
+deps =
+    {[testenv]deps}
+    ordereddict


### PR DESCRIPTION
- Add tox config for running tests under 2.6 and 2.7.
- Add manifest file so non .py files are included in sdist.
