### PR TITLE
Add ordereddict to requirements for python 2.6

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,11 @@
+import sys
 from setuptools import setup, find_packages
 import md5  # fix for "No module named _md5" error
+
+
+requirements = []
+if sys.version_info < (2, 7):
+    requirements.append('ordereddict')
 
 
 setup(name='expiringdict',
@@ -13,4 +19,5 @@ setup(name='expiringdict',
       packages=find_packages(exclude=['tests']),
       include_package_data=True,
       zip_safe=True,
+      install_requires=requirements,
       extras_require={'test': ['nose', 'mock', 'coverage']})

--- a/tox.ini
+++ b/tox.ini
@@ -11,8 +11,3 @@ commands = nosetests
 deps =
     nose
     mock
-
-[testenv:py26]
-deps =
-    {[testenv]deps}
-    ordereddict


### PR DESCRIPTION
Alters the setup.py to add ordereddict to install_requires if installing under
a version less than 2.7.
