### PR TITLE
Add python3 md5 import

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,5 +1,8 @@
 from setuptools import setup, find_packages
-import md5  # fix for "No module named _md5" error
+try:
+    import md5  # fix for "No module named _md5" error
+except ImportError:
+    from hashlib import md5
 
 
 setup(name='expiringdict',


### PR DESCRIPTION
This should allow expiringdict to have python3 support. I ran the tests and everything passed.
