### PR TITLE
Fix race-condition in .items() and .values()

### DIFF
--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -110,7 +110,7 @@ class ExpiringDict(OrderedDict):
     def items(self):
         """ Return a copy of the dictionary's list of (key, value) pairs. """
         r = []
-        for key in self:
+        for key in list(self):
             try:
                 r.append((key, self[key]))
             except KeyError:
@@ -121,7 +121,7 @@ class ExpiringDict(OrderedDict):
         """ Return a copy of the dictionary's list of values.
         See the note for dict.items(). """
         r = []
-        for key in self:
+        for key in list(self):
             try:
                 r.append(self[key])
             except KeyError:

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -121,3 +121,12 @@ def test_not_implemented():
     assert_raises(NotImplementedError, d.viewitems)
     assert_raises(NotImplementedError, d.viewkeys)
     assert_raises(NotImplementedError, d.viewvalues)
+
+
+def test_mutation():
+    d = ExpiringDict(10, 1)
+    d[1] = 1
+    sleep(0.5)
+    d[2] = 2
+    sleep(0.7)
+    d.items()

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27
+envlist = py26, py27, py34
 
 [testenv]
 commands = nosetests


### PR DESCRIPTION
In python3.5, a race-condition in both .items() and .values() can be
triggered. Here's an example script:

```
import expiringdict
import time

d = expiringdict.ExpiringDict(10, 1)
d[1] = 1
time.sleep(0.5)
d[2] = 2
time.sleep(0.7)
print(d.items())
```

Here's what the race-condition looks like:

```
Traceback (most recent call last):
  File "./test.py", line 11, in <module>
    print(d.items())
  File "/home/kormat/expiringdict/__init__.py", line 115, in items
    for key in self:
RuntimeError: OrderedDict mutated during iteration
```

The fix is very simple - make a list of the keys before iterating.

<!-- Reviewable:start -->

---

This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/mailgun/expiringdict/22)

<!-- Reviewable:end -->
