### PR TITLE
fix RuntimeError with Python 3.5

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,5 @@
+venv/*
+
 *.py[cod]
 
 # C extensions

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,14 +1,7 @@
 language: python
 python:
   - "2.7"
-  - "pypy"
-  - "3.2"
-  - "3.3"
-  - "3.4"
-  - "3.5"
   - "3.6"
-  - "nightly"
-  - "pypy3"
 
 sudo: false
 install: "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -3,7 +3,5 @@ python:
     - "2.6"
     - "2.7"
     - "3.5"
-install:
-    pip install tox-travis
-    pip install -r requirements.txt
+install: "pip install -r requirements.txt"
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,6 @@
 language: python
 python:
-  - "2.7"
-  - "3.6"
+  - "3.5"
 
 sudo: false
 install: "pip install -r requirements.txt"

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,7 +1,15 @@
 language: python
 python:
-    - "2.6"
-    - "2.7"
-    - "3.5"
+  - "2.7"
+  - "pypy"
+  - "3.2"
+  - "3.3"
+  - "3.4"
+  - "3.5"
+  - "3.6"
+  - "nightly"
+  - "pypy3"
+
+sudo: false
 install: "pip install -r requirements.txt"
 script: tox

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,0 +1,9 @@
+language: python
+python:
+    - "2.6"
+    - "2.7"
+    - "3.5"
+install:
+    pip install tox-travis
+    pip install -r requirements.txt
+script: tox

--- a/README.rst
+++ b/README.rst
@@ -1,6 +1,8 @@
 expiringdict
 ------------
 
+[![Build Status](https://travis-ci.org/kophy/expiringdict.svg?branch=master)](https://travis-ci.org/kophy/expiringdict)
+
 expiringdict is a Python caching library. The core of the library is ExpiringDict class which
 is an ordered dictionary with auto-expiring values for caching purposes. Expiration happens on
 any access, object is locked during cleanup from expired values. ExpiringDict can not store

--- a/README.rst
+++ b/README.rst
@@ -1,9 +1,6 @@
 expiringdict
 ------------
 
-.. image:: https://travis-ci.org/kophy/expiringdict.svg?branch=master
-    :target: https://travis-ci.org/kophy/expiringdict
-
 expiringdict is a Python caching library. The core of the library is ExpiringDict class which
 is an ordered dictionary with auto-expiring values for caching purposes. Expiration happens on
 any access, object is locked during cleanup from expired values. ExpiringDict can not store

--- a/README.rst
+++ b/README.rst
@@ -1,7 +1,8 @@
 expiringdict
 ------------
 
-[![Build Status](https://travis-ci.org/kophy/expiringdict.svg?branch=master)](https://travis-ci.org/kophy/expiringdict)
+.. image:: https://travis-ci.org/kophy/expiringdict.svg?branch=master
+    :target: https://travis-ci.org/kophy/expiringdict
 
 expiringdict is a Python caching library. The core of the library is ExpiringDict class which
 is an ordered dictionary with auto-expiring values for caching purposes. Expiration happens on

--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -69,7 +69,10 @@ class ExpiringDict(OrderedDict):
         """ Set d[key] to value. """
         with self.lock:
             if len(self) == self.max_len:
-                self.popitem(last=False)
+                try:
+                    self.popitem(last=False)
+                except:
+                    pass
             OrderedDict.__setitem__(self, key, (value, time.time()))
 
     def pop(self, key, default=None):
@@ -110,7 +113,8 @@ class ExpiringDict(OrderedDict):
     def items(self):
         """ Return a copy of the dictionary's list of (key, value) pairs. """
         r = []
-        for key in self:
+        keys = [key for key in self]
+        for key in keys:
             try:
                 r.append((key, self[key]))
             except KeyError:
@@ -121,7 +125,8 @@ class ExpiringDict(OrderedDict):
         """ Return a copy of the dictionary's list of values.
         See the note for dict.items(). """
         r = []
-        for key in self:
+        keys = [key for key in self]
+        for key in keys:
             try:
                 r.append(self[key])
             except KeyError:

--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -17,6 +17,7 @@ NOTE: iteration over dict and also keys() do not remove expired values!
 
 import time
 from threading import RLock
+import sys
 
 try:
     from collections import OrderedDict
@@ -71,7 +72,7 @@ class ExpiringDict(OrderedDict):
             if len(self) == self.max_len:
                 try:
                     self.popitem(last=False)
-                except:
+                except KeyError:
                     pass
             OrderedDict.__setitem__(self, key, (value, time.time()))
 
@@ -113,22 +114,36 @@ class ExpiringDict(OrderedDict):
     def items(self):
         """ Return a copy of the dictionary's list of (key, value) pairs. """
         r = []
-        for key in list(self.keys()):
-            try:
-                r.append((key, self[key]))
-            except KeyError:
-                pass
+        if sys.version_info >= (3, 5):
+            for key in list(self.keys()):
+                try:
+                    r.append((key, self[key]))
+                except KeyError:
+                    pass
+        else:
+            for key in self:
+                try:
+                    r.append((key, self[key]))
+                except KeyError:
+                    pass
         return r
 
     def values(self):
         """ Return a copy of the dictionary's list of values.
         See the note for dict.items(). """
         r = []
-        for key in list(self.keys()):
-            try:
-                r.append(self[key])
-            except KeyError:
-                pass
+        if sys.version_info >= (3, 5):
+            for key in list(self.keys()):
+                try:
+                    r.append(self[key])
+                except KeyError:
+                    pass
+        else:
+            for key in self:
+                try:
+                    r.append(self[key])
+                except KeyError:
+                    pass
         return r
 
     def fromkeys(self):

--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -36,6 +36,11 @@ class ExpiringDict(OrderedDict):
         self.max_age = max_age_seconds
         self.lock = RLock()
 
+        if sys.version_info >= (3, 5):
+            self._safe_keys = lambda: list(self.keys())
+        else:
+            self._safe_keys = self.keys
+
     def __contains__(self, key):
         """ Return True if the dict has a key, else return False. """
         try:
@@ -114,36 +119,22 @@ class ExpiringDict(OrderedDict):
     def items(self):
         """ Return a copy of the dictionary's list of (key, value) pairs. """
         r = []
-        if sys.version_info >= (3, 5):
-            for key in list(self.keys()):
-                try:
-                    r.append((key, self[key]))
-                except KeyError:
-                    pass
-        else:
-            for key in self:
-                try:
-                    r.append((key, self[key]))
-                except KeyError:
-                    pass
+        for key in self._safe_keys():
+            try:
+                r.append((key, self[key]))
+            except KeyError:
+                pass
         return r
 
     def values(self):
         """ Return a copy of the dictionary's list of values.
         See the note for dict.items(). """
         r = []
-        if sys.version_info >= (3, 5):
-            for key in list(self.keys()):
-                try:
-                    r.append(self[key])
-                except KeyError:
-                    pass
-        else:
-            for key in self:
-                try:
-                    r.append(self[key])
-                except KeyError:
-                    pass
+        for key in self._safe_keys():
+            try:
+                r.append(self[key])
+            except KeyError:
+                pass
         return r
 
     def fromkeys(self):

--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -26,7 +26,7 @@ except ImportError:
 
 
 class ExpiringDict(OrderedDict):
-    def __init__(self, max_len, max_age_seconds, callback = None):
+    def __init__(self, max_len, max_age_seconds):
         assert max_age_seconds >= 0
         assert max_len >= 1
 
@@ -34,7 +34,6 @@ class ExpiringDict(OrderedDict):
         self.max_len = max_len
         self.max_age = max_age_seconds
         self.lock = RLock()
-        self.callback = callback
 
     def __contains__(self, key):
         """ Return True if the dict has a key, else return False. """
@@ -44,8 +43,6 @@ class ExpiringDict(OrderedDict):
                 if time.time() - item[1] < self.max_age:
                     return True
                 else:
-                    if self.callback:
-                        self.callback(key, item[0])
                     del self[key]
         except KeyError:
             pass
@@ -65,8 +62,6 @@ class ExpiringDict(OrderedDict):
                 else:
                     return item[0]
             else:
-                if self.callback:
-                    self.callback(key, item[0])
                 del self[key]
                 raise KeyError(key)
 
@@ -88,8 +83,6 @@ class ExpiringDict(OrderedDict):
         with self.lock:
             try:
                 item = OrderedDict.__getitem__(self, key)
-                if self.callback:
-                    self.callback(key, item[0])
                 del self[key]
                 return item[0]
             except KeyError:

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,0 +1,13 @@
+appdirs==1.4.3
+coverage==4.4.1
+funcsigs==1.0.2
+mock==2.0.0
+nose==1.3.7
+packaging==16.8
+pbr==3.0.1
+pluggy==0.4.0
+py==1.4.33
+pyparsing==2.2.0
+six==1.10.0
+tox==2.7.0
+virtualenv==15.1.0

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -97,7 +97,7 @@ def test_ttl():
     eq_(None, d.ttl('b'))
 
     # expired key
-    with patch.object(OrderedDict, '__getitem__',
+    with patch.object(ExpiringDict, '__getitem__',
                       Mock(return_value=('x', 10**9))):
         eq_(None, d.ttl('a'))
 

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -121,3 +121,12 @@ def test_not_implemented():
     assert_raises(NotImplementedError, d.viewitems)
     assert_raises(NotImplementedError, d.viewkeys)
     assert_raises(NotImplementedError, d.viewvalues)
+
+def test_callback():
+    callback = Mock()
+    d = ExpiringDict(max_len=10, max_age_seconds=0.01, callback=callback)
+
+    d['a'] = 'x'
+    sleep(0.01)
+    d.items()
+    callback.assert_called_with('a', 'x')

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -121,12 +121,3 @@ def test_not_implemented():
     assert_raises(NotImplementedError, d.viewitems)
     assert_raises(NotImplementedError, d.viewkeys)
     assert_raises(NotImplementedError, d.viewvalues)
-
-def test_callback():
-    callback = Mock()
-    d = ExpiringDict(max_len=10, max_age_seconds=0.01, callback=callback)
-
-    d['a'] = 'x'
-    sleep(0.01)
-    d.items()
-    callback.assert_called_with('a', 'x')

--- a/tox.ini
+++ b/tox.ini
@@ -4,7 +4,7 @@
 # and then run "tox" from this directory.
 
 [tox]
-envlist = py26, py27
+envlist = py26, py27, py35
 
 [testenv]
 commands = nosetests


### PR DESCRIPTION
1. fix Python 3.5 RuntimeError mentioned in issue #25 
2. add callback support for expired items (personally think it's useful)