### PR TITLE
Handle ModuleNotFoundError error raised during installation

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -1,7 +1,7 @@
 from setuptools import setup, find_packages
 try:
     import md5  # fix for "No module named _md5" error
-except ImportError:
+except (ImportError, ModuleNotFoundError):
     # python 3 moved md5
     from hashlib import md5
 


### PR DESCRIPTION
My Python version is 3.6.1 and I get this error during installation:

```
Collecting expiringdict
  Downloading expiringdict-1.1.3.tar.gz
    Complete output from command python setup.py egg_info:
    Traceback (most recent call last):
      File "<string>", line 1, in <module>
      File "/private/var/folders/0n/qnll4nm56h5b98_r8x3yfpc80000gn/T/pip-build-nrgukvzy/expiringdict/setup.py", line 2, in <module>
        import md5  # fix for "No module named _md5" error
    ModuleNotFoundError: No module named 'md5'

    ----------------------------------------
Command "python setup.py egg_info" failed with error code 1 in /private/var/folders/0n/qnll4nm56h5b98_r8x3yfpc80000gn/T/pip-build-nrgukvzy/expiringdict/
```