### PR TITLE
Clean up on length call to give accurate dictionary length based on expiration

### DIFF
--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -55,6 +55,19 @@ class ExpiringDict(OrderedDict):
             else:
                 raise ValueError('can not unpack items')
 
+    def __len__(self):
+        current_key = iter(self)
+        for k in current_key:
+            item = OrderedDict.__getitem__(self, k)
+            time_added = item[1]
+            item_age = time.time() - time_added
+            if item_age > self.max_age:
+                del self[k]
+            else:
+                break
+
+        return super(ExpiringDict, self).__len__()
+
     def __contains__(self, key):
         """ Return True if the dict has a key, else return False. """
         try:

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -65,7 +65,7 @@ def test_repr():
     d['a'] = 'x'
     eq_(str(d), "ExpiringDict([('a', 'x')])")
     sleep(0.01)
-    eq_(str(d), "ExpiringDict([])")
+    eq_(str(d), "ExpiringDict()")
 
 
 def test_iter():
@@ -122,3 +122,46 @@ def test_not_implemented():
     assert_raises(NotImplementedError, d.viewitems)
     assert_raises(NotImplementedError, d.viewkeys)
     assert_raises(NotImplementedError, d.viewvalues)
+
+
+def test_cleanup_on_length():
+    d = ExpiringDict(max_len=10, max_age_seconds=0.01)
+    d['a'] = 'x'
+    eq_(1, len(d))
+    sleep(0.01)
+    eq_(0, len(d))
+
+    d = ExpiringDict(max_len=10, max_age_seconds=0.02)
+    d['a'] = 1
+    sleep(0.01)
+    eq_(1, len(d))
+    d['b'] = 2
+    sleep(0.01)
+    eq_(1, len(d))
+    d['c'] = 3
+    sleep(0.01)
+    eq_(1, len(d))
+    d['d'] = 4
+    sleep(0.01)
+    eq_(1, len(d))
+
+    d = ExpiringDict(max_len=1000, max_age_seconds=.5)
+    d[1] = 1
+    d[2] = 2
+    d[3] = 3
+    d[4] = 4
+
+    ok_(1 in d)
+    ok_(2 in d)
+    ok_(3 in d)
+    ok_(4 in d)
+    eq_(4, len(d))
+
+    sleep(.25)
+    d[1] = 1
+    d[2] = 2
+    sleep(.40)
+    ok_(1 in d)
+    ok_(2 in d)
+    ok_(3 not in d)
+    ok_(4 not in d)


### PR DESCRIPTION
Clean up on length call to give accurate dictionary length based on expiration

Performance wise, it shouldn't make a big impact. `__setitem__` calls `len()` to check for the length of the dictionary. This will also make it much more accurate; only expired items will be popped from the list.

But the main motive for this push is because len(expiringdict) was inaccurate. Added unit tests.