### PR TITLE
Fix bug when setting existing key in full dict (minimal version of PR #32)

### DIFF
--- a/expiringdict/__init__.py
+++ b/expiringdict/__init__.py
@@ -89,10 +89,13 @@ class ExpiringDict(OrderedDict):
         """ Set d[key] to value. """
         with self.lock:
             if len(self) == self.max_len:
-                try:
-                    self.popitem(last=False)
-                except KeyError:
-                    pass
+                if key in self:
+                    del self[key]
+                else:
+                    try:
+                        self.popitem(last=False)
+                    except KeyError:
+                        pass
             if set_time is None:
                 set_time = time.time()
             OrderedDict.__setitem__(self, key, (value, set_time))

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -122,3 +122,14 @@ def test_not_implemented():
     assert_raises(NotImplementedError, d.viewitems)
     assert_raises(NotImplementedError, d.viewkeys)
     assert_raises(NotImplementedError, d.viewvalues)
+
+
+def test_reset_of_key_no_trim():
+    """Re-setting an existing key should not cause a non-expired key to be dropped"""
+    d = ExpiringDict(max_len=2, max_age_seconds=10)
+    d["a"] = "A"
+    d["b"] = "B"
+
+    d["b"] = "B"
+
+    assert "a" in d


### PR DESCRIPTION
Minimal version of PR #32 without adding a counter.

Line 133 in the test file would trigger the logic to unconditionally drop the oldest element at key `'a'` without checking if we're going to overwrite an additional element and not actually extend the size of the dictionary.