### PR TITLE
Fix typing conflict on Python 3.7

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -37,7 +37,7 @@ setup(name="expiringdict",
       zip_safe=True,
       tests_require=tests_require,
       install_requires=[
-          "typing",
+          'typing;python_version<"3.5"',
       ],
       extras_require={
           "tests": tests_require,


### PR DESCRIPTION
When using bazel on Python3.7, I got error message below
```
Traceback (most recent call last):
  File "/private/var/tmp/_bazel_yujo/abf0a3d83a4b1d722a32424a453d5c05/sandbox/darwin-sandbox/39/execroot/__main__/bazel-out/darwin-fastbuild/bin/tests/unit/unit_tests.runfiles/__main__/tests/unit/runner.py", line 2, in <module>
    from typing import Any
  File "/private/var/tmp/_bazel_yujo/abf0a3d83a4b1d722a32424a453d5c05/sandbox/darwin-sandbox/39/execroot/__main__/bazel-out/darwin-fastbuild/bin/tests/unit/unit_tests.runfiles/pip_deps_pypi__typing_3_7_4_1/typing.py", line 1357, in <module>
    class Callable(extra=collections_abc.Callable, metaclass=CallableMeta):
  File "/private/var/tmp/_bazel_yujo/abf0a3d83a4b1d722a32424a453d5c05/sandbox/darwin-sandbox/39/execroot/__main__/bazel-out/darwin-fastbuild/bin/tests/unit/unit_tests.runfiles/pip_deps_pypi__typing_3_7_4_1/typing.py", line 1005, in __new__
    self._abc_registry = extra._abc_registry
AttributeError: type object 'Callable' has no attribute '_abc_registry'
```

After some research, I found this is because expiringdict requires 'typing' regardless of Python version. 
From [typing doc](https://docs.python.org/3/library/typing.html), it becomes part of standard library in python 3.5.