### PR TITLE
Use pytest/bare asserts in tests

### DIFF
--- a/tests/expiringdict_extended_test.py
+++ b/tests/expiringdict_extended_test.py
@@ -1,5 +1,3 @@
-from nose.tools import eq_
-
 from expiringdict import ExpiringDict
 import dill
 
@@ -15,29 +13,29 @@ def test_expiring_dict_pickle():
     exp_dict_test['test'] = 1
     pickled_object = dill.dumps(exp_dict_test)
     original_object = dill.loads(pickled_object)  # doctest: +ELLIPSIS +NORMALIZE_WHITESPACE
-    eq_(1, original_object['test'])
+    assert 1 == original_object['test']
 
 
 def test_expiring_dict_copy_from_dict():
     dict_test = dict()
     dict_test['test'] = 1
     exp_dict_test = ExpiringDict(max_len=200000, max_age_seconds=1800, items=dict_test)
-    eq_(1, exp_dict_test['test'])
+    assert 1 == exp_dict_test['test']
 
 
 def test_expiring_dict_copy_from_expiring_dict_original_timeout_and_length():
     exp_dict_test = ExpiringDict(max_len=200000, max_age_seconds=1800)
     exp_dict_test['test'] = 1
     exp_dict_test2 = ExpiringDict(max_len=None, max_age_seconds=None, items=exp_dict_test)
-    eq_(1, exp_dict_test2['test'])
-    eq_(200000, exp_dict_test2.max_len)
-    eq_(1800, exp_dict_test2.max_age)
+    assert 1 == exp_dict_test2['test']
+    assert 200000 == exp_dict_test2.max_len
+    assert 1800 == exp_dict_test2.max_age
 
 
 def test_expiring_dict_copy_from_expiring_dict_new_timeout_and_length():
     exp_dict_test = ExpiringDict(max_len=200000, max_age_seconds=1800)
     exp_dict_test['test'] = 1
     exp_dict_test2 = ExpiringDict(max_len=100000, max_age_seconds=900, items=exp_dict_test)
-    eq_(1, exp_dict_test2['test'])
-    eq_(100000, exp_dict_test2.max_len)
-    eq_(900, exp_dict_test2.max_age)
+    assert 1 == exp_dict_test2['test']
+    assert 100000 == exp_dict_test2.max_len
+    assert 900 == exp_dict_test2.max_age

--- a/tests/expiringdict_test.py
+++ b/tests/expiringdict_test.py
@@ -1,38 +1,40 @@
 from time import sleep
 
 from mock import Mock, patch
-from nose.tools import assert_raises, eq_, ok_
 
 from expiringdict import ExpiringDict
 
+from pytest import raises
+
 
 def test_create():
-    assert_raises(AssertionError, ExpiringDict, max_len=1, max_age_seconds=-1)
-    assert_raises(AssertionError, ExpiringDict, max_len=0, max_age_seconds=1)
+    with raises(AssertionError):
+        ExpiringDict(max_len=1, max_age_seconds=-1)
+        ExpiringDict(max_len=0, max_age_seconds=1)
 
     d = ExpiringDict(max_len=3, max_age_seconds=0.01)
-    eq_(len(d), 0)
+    assert len(d) == 0
 
 
 def test_basics():
     d = ExpiringDict(max_len=3, max_age_seconds=0.01)
 
-    eq_(d.get('a'), None)
+    assert d.get('a') is None
     d['a'] = 'x'
-    eq_(d.get('a'), 'x')
+    assert d.get('a') == 'x'
 
     sleep(0.01)
-    eq_(d.get('a'), None)
+    assert d.get('a') is None
 
     d['a'] = 'y'
-    eq_(d.get('a'), 'y')
+    assert d.get('a') == 'y'
 
-    ok_('b' not in d)
+    assert 'b' not in d
     d['b'] = 'y'
-    ok_('b' in d)
+    assert 'b' in d
 
     sleep(0.01)
-    ok_('b' not in d)
+    assert 'b' not in d
 
     # a is still in expiringdict, next values should expire it
     d['c'] = 'x'
@@ -40,53 +42,53 @@ def test_basics():
     d['e'] = 'z'
 
     # dict if full
-    ok_('c' in d)
-    ok_('d' in d)
+    assert 'c' in d
+    assert 'd' in d
 
     d['f'] = '1'
     # c should gone after that
-    ok_('c' not in d, 'Len of dict is more than max_len')
+    assert 'c' not in d, 'Len of dict is more than max_len'
 
     # test __delitem__
     del d['e']
-    ok_('e' not in d)
+    assert 'e' not in d
 
 
 def test_pop():
     d = ExpiringDict(max_len=3, max_age_seconds=0.01)
     d['a'] = 'x'
-    eq_('x', d.pop('a'))
+    assert 'x' == d.pop('a')
     sleep(0.01)
-    eq_(None, d.pop('a'))
+    assert d.pop('a') is None
 
 
 def test_repr():
     d = ExpiringDict(max_len=2, max_age_seconds=0.01)
     d['a'] = 'x'
-    eq_(str(d), "ExpiringDict([('a', 'x')])")
+    assert str(d) == "ExpiringDict([('a', 'x')])"
     sleep(0.01)
-    eq_(str(d), "ExpiringDict([])")
+    assert str(d) == "ExpiringDict([])"
 
 
 def test_iter():
     d = ExpiringDict(max_len=10, max_age_seconds=0.01)
-    eq_([k for k in d], [])
+    assert [k for k in d] == []
     d['a'] = 'x'
     d['b'] = 'y'
     d['c'] = 'z'
-    eq_([k for k in d], ['a', 'b', 'c'])
+    assert [k for k in d] == ['a', 'b', 'c']
 
-    eq_([k for k in d.values()], ['x', 'y', 'z'])
+    assert [k for k in d.values()] == ['x', 'y', 'z']
     sleep(0.01)
-    eq_([k for k in d.values()], [])
+    assert [k for k in d.values()] == []
 
 
 def test_clear():
     d = ExpiringDict(max_len=10, max_age_seconds=10)
     d['a'] = 'x'
-    eq_(len(d), 1)
+    assert len(d) == 1
     d.clear()
-    eq_(len(d), 0)
+    assert len(d) == 0
 
 
 def test_ttl():
@@ -94,34 +96,35 @@ def test_ttl():
     d['a'] = 'x'
 
     # existent non-expired key
-    ok_(0 < d.ttl('a') < 10)
+    assert 0 < d.ttl('a') < 10
 
     # non-existent key
-    eq_(None, d.ttl('b'))
+    assert d.ttl('b') is None
 
     # expired key
     with patch.object(ExpiringDict, '__getitem__',
                       Mock(return_value=('x', 10**9))):
-        eq_(None, d.ttl('a'))
+        assert d.ttl('a') is None
 
 
 def test_setdefault():
     d = ExpiringDict(max_len=10, max_age_seconds=0.01)
 
-    eq_('x', d.setdefault('a', 'x'))
-    eq_('x', d.setdefault('a', 'y'))
+    assert d.setdefault('a', 'x') == 'x'
+    assert d.setdefault('a', 'y') == 'x'
 
     sleep(0.01)
 
-    eq_('y', d.setdefault('a', 'y'))
+    assert d.setdefault('a', 'y') == 'y'
 
 
 def test_not_implemented():
     d = ExpiringDict(max_len=10, max_age_seconds=10)
-    assert_raises(NotImplementedError, d.fromkeys)
-    assert_raises(NotImplementedError, d.viewitems)
-    assert_raises(NotImplementedError, d.viewkeys)
-    assert_raises(NotImplementedError, d.viewvalues)
+    with raises(NotImplementedError):
+        d.fromkeys()
+        d.viewitems()
+        d.viewkeys()
+        d.viewvalues()
 
 
 def test_reset_of_key_no_trim():


### PR DESCRIPTION
nose has been unmaintained upstream for years now, and so this project
should move with the times. To that end, switch to either using bare
assert statements, or where that isn't suitable, using pytest's raises
context manager.